### PR TITLE
Add image persistence and auto-generated session names

### DIFF
--- a/AIAgentTest/Models/ChatSession.cs
+++ b/AIAgentTest/Models/ChatSession.cs
@@ -35,5 +35,6 @@ namespace AIAgentTest.Models
         public string Role { get; set; }
         public string Content { get; set; }
         public DateTime Timestamp { get; set; } = DateTime.Now;
+        public string ImagePath { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds two major features to improve the chat experience:

1. **Image Persistence**
- Added ImagePath property to ChatMessage model
- Implemented image storage in AppData folder
- Added functionality to copy and persist images across sessions
- Updated LoadSessionContent to display saved images

2. **Smart Session Naming**
- Added automatic session name generation after 6 messages
- Names are AI-generated based on conversation context
- Limited to 30 characters for readability
- Names are saved with sessions

Additional improvements:
- Fixed session selection in UI by updating SessionsComboBox
- Added null checks for CurrentSession
- Improved error handling for image operations