### PR TITLE
Add Light/Dark Theme Support

### DIFF
--- a/AIAgentTest/UI/MainWindow.xaml
+++ b/AIAgentTest/UI/MainWindow.xaml
@@ -1,4 +1,5 @@
 <Window x:Class="AIAgentTest.UI.MainWindow"
+        Style="{DynamicResource WindowStyle}"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -8,7 +9,19 @@
         Title="AI Agent Framework" Height="800" Width="1500">
 
     <Window.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <ResourceDictionary>
+            <!-- Light Theme -->
+            <SolidColorBrush x:Key="BackgroundBrush" Color="#FFFFFF"/>
+            <SolidColorBrush x:Key="ForegroundBrush" Color="#000000"/>
+            <SolidColorBrush x:Key="BorderBrush" Color="#CCCCCC"/>
+            
+            <!-- Dark Theme -->
+            <SolidColorBrush x:Key="BackgroundBrushDark" Color="#2D2D2D"/>
+            <SolidColorBrush x:Key="ForegroundBrushDark" Color="#FFFFFF"/>
+            <SolidColorBrush x:Key="BorderBrushDark" Color="#404040"/>
+            
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        </ResourceDictionary>
     </Window.Resources>
 
     <DockPanel>
@@ -21,6 +34,9 @@
                 <MenuItem Header="_Exit" Click="Exit_Click"/>
             </MenuItem>
             <MenuItem Header="_View">
+                <MenuItem Header="Light Theme" Click="ThemeMenuItem_Click" IsChecked="{Binding IsLightTheme}"/>
+                <MenuItem Header="Dark Theme" Click="ThemeMenuItem_Click" IsChecked="{Binding IsDarkTheme}"/>
+                <Separator/>
                 <MenuItem Header="Show _Debug Window" 
                           IsCheckable="True" 
                           IsChecked="{Binding IsDebugVisible}"

--- a/AIAgentTest/UI/MainWindow.xaml.cs
+++ b/AIAgentTest/UI/MainWindow.xaml.cs
@@ -51,6 +51,20 @@ namespace AIAgentTest.UI
         private string _inputText;
         private bool _isDebugVisible = true;
         private bool _isContextEnabled = true;
+        private bool _isLightTheme = true;
+    
+        public bool IsLightTheme
+        {
+            get => _isLightTheme;
+            set
+            {
+                _isLightTheme = value;
+                OnPropertyChanged(nameof(IsLightTheme));
+                OnPropertyChanged(nameof(IsDarkTheme));
+            }
+        }
+    
+        public bool IsDarkTheme => !IsLightTheme;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -138,6 +152,8 @@ namespace AIAgentTest.UI
             _chatSessions = new ObservableCollection<ChatSession>();
             InitializeComponent();
             DataContext = this;
+            IsLightTheme = Properties.Settings.Default.IsLightTheme;
+            ApplyTheme(IsLightTheme);
 
             _ollamaClient = new OllamaClient();
             _contextManager = new ContextManager(_ollamaClient);
@@ -681,6 +697,26 @@ namespace AIAgentTest.UI
 
             var fullContext = _contextManager.GetFullContext();
             SetRichTextContent(DebugBox, fullContext);
+        }
+
+        private void ApplyTheme(bool isLight)
+        {
+            var theme = isLight ? "BackgroundBrush" : "BackgroundBrushDark";
+            var foreground = isLight ? "ForegroundBrush" : "ForegroundBrushDark";
+            var border = isLight ? "BorderBrush" : "BorderBrushDark";
+            
+            Resources["BackgroundBrush"] = Resources[isLight ? "BackgroundBrush" : "BackgroundBrushDark"];
+            Resources["ForegroundBrush"] = Resources[isLight ? "ForegroundBrush" : "ForegroundBrushDark"]; 
+            Resources["BorderBrush"] = Resources[isLight ? "BorderBrush" : "BorderBrushDark"];
+            
+            Properties.Settings.Default.IsLightTheme = isLight;
+            Properties.Settings.Default.Save();
+        }
+
+        private void ThemeMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            IsLightTheme = ((MenuItem)sender).Header.ToString() == "Light Theme";
+            ApplyTheme(IsLightTheme);
         }
 
         protected virtual void OnPropertyChanged(string propertyName)

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
+  <Profiles>
+    <Profile Name="(Default)" />
+  </Profiles>
+  <Settings>
+    <Setting Name="IsLightTheme" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+  </Settings>
+</SettingsFile>


### PR DESCRIPTION
This PR adds light and dark theme support to the application with the following changes:

- Added theme resource definitions for light/dark modes (background, foreground, border colors)
- Added View menu items to switch between themes
- Implemented theme switching logic in MainWindow.xaml.cs
- Added persistent theme setting in Settings.settings
- Theme preference is saved and restored between sessions

The default theme is light, but users can switch to dark theme via the View menu. The selected theme persists across application restarts.