### PR TITLE
Add theme settings support with user preferences

### DIFF
--- a/AIAgentTest/AIAgentTest.csproj
+++ b/AIAgentTest/AIAgentTest.csproj
@@ -7,7 +7,19 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
 	<ApplicationDefinition>App.xaml</ApplicationDefinition>
-</PropertyGroup>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.65" />

--- a/AIAgentTest/Properties/Settings.Designer.cs
+++ b/AIAgentTest/Properties/Settings.Designer.cs
@@ -1,0 +1,27 @@
+namespace AIAgentTest.Properties {
+    
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.0.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
+        private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
+        
+        public static Settings Default {
+            get {
+                return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool IsLightTheme {
+            get {
+                return ((bool)(this["IsLightTheme"]));
+            }
+            set {
+                this["IsLightTheme"] = value;
+            }
+        }
+    }
+}

--- a/AIAgentTest/Properties/Settings.settings
+++ b/AIAgentTest/Properties/Settings.settings
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="AIAgentTest.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="IsLightTheme" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+  </Settings>
+</SettingsFile>

--- a/AIAgentTest/UI/MainWindow.xaml
+++ b/AIAgentTest/UI/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AIAgentTest.UI"
+        xmlns:properties="clr-namespace:AIAgentTest.Properties"
         mc:Ignorable="d"
         Title="AI Agent Framework" Height="800" Width="1500">
 

--- a/AIAgentTest/UI/MainWindow.xaml.cs
+++ b/AIAgentTest/UI/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows;
+using AIAgentTest.Properties;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;


### PR DESCRIPTION
This PR adds theme settings support to the application with user preference persistence. Changes include:

- Added Settings.settings file with IsLightTheme user preference
- Created Settings.Designer.cs for strongly-typed settings access
- Updated MainWindow.xaml with Properties namespace reference
- Modified project file to support settings generation
- Added Settings namespace reference in MainWindow.xaml.cs

These changes establish the foundation for theme switching functionality with persistent user preferences between application sessions.